### PR TITLE
Fix for calling super with parameters object literal

### DIFF
--- a/dst/RedisAffinity.js
+++ b/dst/RedisAffinity.js
@@ -66,7 +66,7 @@ class RedisAffinity extends zeebe_node_1.ZBClient {
     async createProcessInstanceWithAffinity({ bpmnProcessId, variables, cb, }) {
         try {
             // create process instance (ZB client)
-            const wfi = await super.createProcessInstance(bpmnProcessId, variables);
+            const wfi = await super.createProcessInstance({bpmnProcessId, variables});
             this.affinityCallbacks[wfi.processInstanceKey] = cb;
             this.subscriber.subscribe(wfi.processInstanceKey, () => {
                 console.log(`Subscribe to channel ${wfi.processInstanceKey}`);

--- a/dst/ZeebeAffinityClient.js
+++ b/dst/ZeebeAffinityClient.js
@@ -46,7 +46,7 @@ class ZBAffinityClient extends zeebe_node_1.ZBClient {
     async createProcessInstanceWithAffinity({ bpmnProcessId, variables, cb, }) {
         await this.waitForAffinity();
         // TODO check for error creating process to prevent registering callback?
-        const wfi = await super.createProcessInstance(bpmnProcessId, variables);
+        const wfi = await super.createProcessInstance({bpmnProcessId, variables});
         if (this.affinityService) {
             this.affinityCallbacks[wfi.processInstanceKey] = cb; // Register callback for application code
         }

--- a/src/RedisAffinity.ts
+++ b/src/RedisAffinity.ts
@@ -87,10 +87,10 @@ export class RedisAffinity extends ZBClient {
     }): Promise<void> {
         try {
             // create process instance (ZB client)
-            const wfi = await super.createProcessInstance(
+            const wfi = await super.createProcessInstance({
                 bpmnProcessId,
                 variables,
-            );
+            });
 
             this.affinityCallbacks[wfi.processInstanceKey] = cb;
 

--- a/src/ZeebeAffinityClient.ts
+++ b/src/ZeebeAffinityClient.ts
@@ -81,7 +81,7 @@ export class ZBAffinityClient extends ZBClient {
         await this.waitForAffinity();
 
         // TODO check for error creating process to prevent registering callback?
-        const wfi = await super.createProcessInstance(bpmnProcessId, variables);
+        const wfi = await super.createProcessInstance({bpmnProcessId, variables});
         if (this.affinityService) {
             this.affinityCallbacks[wfi.processInstanceKey] = cb; // Register callback for application code
         }


### PR DESCRIPTION
Unlike syntax super.functionName.call(param1, param2....), where the params are inside parentheses as comma separated, there was an error that the super.createProcessInstance(...) was being called with parameters without a object literal {} wrapper around them.
This fixes the issue.